### PR TITLE
Fix: Correct DataAPI socket connection and restore node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "mongodb": "^6.12.0",
         "mongoose": "^8.9.5",
         "mqtt": "^5.10.3",
+        "node-fetch": "^2.7.0",
         "node-os-utils": "^1.3.5",
         "nodemailer": "^6.4.16",
         "nodemailer-smtp-transport": "^2.4.2",
@@ -2120,6 +2121,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-os-utils": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mongodb": "^6.12.0",
     "mongoose": "^8.9.5",
     "mqtt": "^5.10.3",
+    "node-fetch": "^2.7.0",
     "node-os-utils": "^1.3.5",
     "nodemailer": "^6.4.16",
     "nodemailer-smtp-transport": "^2.4.2",

--- a/scripts/socket.js
+++ b/scripts/socket.js
@@ -49,8 +49,8 @@ function get_io() { assert.ok(io_, "IO has not been initialized. Please called i
 function get_sockets() { return connectedSockets; }
 
 // --- DataAPI Client Logic ---
-const DATA_API_SOCKET_URL = 'http://data.specialblend.ca';
-const dataApiClient = ioClient(DATA_API_SOCKET_URL);
+const DATA_API_SOCKET_URL = 'https://data.specialblend.ca';
+const dataApiClient = ioClient(DATA_API_SOCKET_URL, { secure: true, transports: ['websocket', 'polling'] });
 
 dataApiClient.on('connect', () => {
     console.log('Successfully connected to DataAPI socket server at', DATA_API_SOCKET_URL);


### PR DESCRIPTION
This commit addresses two critical issues identified from server logs:

1.  **Restored `node-fetch` dependency:** `node-fetch@^2` has been reinstalled. The `scripts/esp32.js` file depends on `node-fetch` for its operations. Its inadvertent removal in a previous commit led to `ERR_MODULE_NOT_FOUND` errors, impacting ESP32 device communication and Data API interactions.

2.  **Corrected DataAPI Socket.IO connection URL:** In `scripts/socket.js`, the URL for connecting to the external DataAPI's Socket.IO server has been updated from `http` to `https`. Connection options (`secure: true`, `transports: ['websocket', 'polling']`) have also been added. This resolves the '301 Moved Permanently' error that prevented the server from receiving live ISS data updates from the DataAPI.

These changes should ensure the stability of ESP32-related features and enable the correct event-driven relay of live ISS data to clients.