### PR TITLE
Fix: Use IcosahedronGeometry in sceneSubject.js

### DIFF
--- a/public/Projects/3D Playground/scene/sceneSubject.js
+++ b/public/Projects/3D Playground/scene/sceneSubject.js
@@ -1,4 +1,4 @@
-import { Mesh, IcosahedronBufferGeometry, MeshStandardMaterial} from 'three'
+import { Mesh, IcosahedronGeometry, MeshStandardMaterial} from 'three'
 
 export class SceneSubject {
 
@@ -7,7 +7,7 @@ export class SceneSubject {
     constructor(scene) {
 	
         const radius = 2;
-        this.mesh = new Mesh(new IcosahedronBufferGeometry(radius, 2), new MeshStandardMaterial({ flatShading: true }));
+        this.mesh = new Mesh(new IcosahedronGeometry(radius, 2), new MeshStandardMaterial({ flatShading: true }));
         this.mesh.position.set(0, 0, -20);
         scene.add(this.mesh);
     }


### PR DESCRIPTION
The `IcosahedronBufferGeometry` export was removed in recent versions of three.js. This commit updates the code to use `IcosahedronGeometry` instead, which is the current correct class name.

This resolves the SyntaxError: "The requested module 'three' does not provide an export named 'IcosahedronBufferGeometry'".