### PR TITLE
Fix: Address runtime errors in 3D Playground

### DIFF
--- a/public/Projects/3D Playground/index.html
+++ b/public/Projects/3D Playground/index.html
@@ -133,7 +133,11 @@
                         kFps.style.color = "black"
                         kFps.textContent = fps + " FPS"
                     }
-                    kpFps.value = fps
+                    if (isFinite(fps)) {
+                        kpFps.value = fps;
+                    } else {
+                        kpFps.value = 0; // Or some other default value
+                    }
                 }
             )
 

--- a/public/Projects/3D Playground/scene/planeZ.js
+++ b/public/Projects/3D Playground/scene/planeZ.js
@@ -1,4 +1,4 @@
-import { PlaneGeometry, MeshPhongMaterial, Mesh, DoubleSide, FlatShading } from 'three'
+import { PlaneGeometry, MeshPhongMaterial, Mesh, DoubleSide } from 'three'
 import * as GraphysX from '../GraphysX/graphysx.js'
 import { World } from './world.js'
 
@@ -12,7 +12,7 @@ export class PlaneZ {
         const width = World.plane.width ? World.plane.width : 10
         const height = World.plane.height ? World.plane.height : 10
         const geoPlane = new PlaneGeometry(width,height,width, height)
-        const matPlane = new MeshPhongMaterial({ color: 0xff0000, side: DoubleSide, flatShading: FlatShading })
+        const matPlane = new MeshPhongMaterial({ color: 0xff0000, side: DoubleSide, flatShading: true })
         this.mesh = new Mesh(geoPlane, matPlane)
         GraphysX.randomVertexZ(this.mesh, width, height)
         scene.add(this.mesh)


### PR DESCRIPTION
This commit includes two fixes:

1. Prevents a TypeError in the FPS counter in `index.html` by ensuring the FPS value is finite before updating the progress bar.
2. Resolves a SyntaxError in `planeZ.js` by removing the outdated `FlatShading` import and updating the material to use `flatShading: true`, which is the modern way to specify flat shading in three.js.