### PR TITLE
Fix: Improve ISS path rendering and extend track history

### DIFF
--- a/views/earth.ejs
+++ b/views/earth.ejs
@@ -146,8 +146,9 @@ let clientLon = null;
 
 // For 2D path
 let issPathHistory = [];
-const MAX_2D_HISTORY_POINTS = 200;
-let issPathPolyline = null;
+const MAX_2D_HISTORY_POINTS = 1500;
+let issPathPolyline = null; // Live ISS path
+let historicalIssPathPolyline = null; // Historical ISS path from initial load
 let mymap; // Declare mymap globally
 
 // For Predicted Path
@@ -340,6 +341,35 @@ async function updateIssOnMap(lat, lon) {
             weight: 3,
             dashArray: '5, 10'
         }).addTo(mymap);
+    }
+}
+
+function displayHistoricalDataOn2DMap(historicalPoints) {
+    console.log('[Historical Path] displayHistoricalDataOn2DMap called with', historicalPoints.length, 'points.');
+
+    if (historicalIssPathPolyline && mymap) {
+        mymap.removeLayer(historicalIssPathPolyline);
+        console.log('[Historical Path] Removed existing historical polyline from 2D map.');
+    }
+
+    if (!historicalPoints || historicalPoints.length === 0) {
+        console.log('[Historical Path] No points provided or empty array, historical path will not be drawn.');
+        historicalIssPathPolyline = null; // Ensure it's cleared if no points
+        return;
+    }
+
+    const latLngs = historicalPoints.map(p => [p.lat, p.lon]); // Note: earth3D.js uses p.lon
+
+    if (latLngs.length > 1 && mymap) {
+        historicalIssPathPolyline = L.polyline(latLngs, {
+            color: 'orange', // Different color for historical path
+            weight: 3,
+            dashArray: '5, 5' // Dashed line for distinction
+        }).addTo(mymap);
+        console.log('[Historical Path] Historical ISS path drawn on 2D map with', latLngs.length, 'points.');
+    } else {
+        console.log('[Historical Path] Not enough points to draw historical ISS path on 2D map (need > 1) or mymap not ready. Points:', latLngs.length);
+        historicalIssPathPolyline = null; // Ensure it's cleared if not drawn
     }
 }
 


### PR DESCRIPTION
This commit addresses issues with the ISS tracer visualization:

1.  **Corrects 3D Historical Path:**
    - Modified `public/js/earth3D.js` to sort the initial ISS path data (fetched from an external API) by timestamp before processing.
    - This ensures that the displayed historical path is a coherent segment of the orbit, resolving an issue where unsorted data could lead to a disjointed or very short path appearing as "3 strokes on the same path".
    - The function now slices the most recent data points if the API provides more than `MAX_HISTORY_POINTS`.

2.  **Adds Historical Path to 2D Map:**
    - Enhanced `views/earth.ejs` to draw the historical ISS path (loaded by `earth3D.js`) on the 2D Leaflet map.
    - This historical path is styled with an orange dashed line to distinguish it from the live blue ISS path fed by WebSockets.
    - `public/js/earth3D.js` was updated to call a new function in `views/earth.ejs` to render this path once data is available.

3.  **Increases Path History Limit:**
    - Increased `MAX_HISTORY_POINTS` in `public/js/earth3D.js` and `MAX_2D_HISTORY_POINTS` in `views/earth.ejs` from 200 to 1500.
    - This allows for a significantly longer ISS track to accumulate from live WebSocket data over time, better addressing your request to see the path "cycling around earth multiple times."

4.  **API Investigation Note:**
    - Investigation of the external API (`https://data.specialblend.ca/iss`) indicated it returns a fixed set of ~288 points by default, and common `limit` parameters did not alter this. The application now correctly processes this available data.

These changes improve the accuracy of the historical ISS path display and enhance the long-term tracking capabilities of the visualization on both 2D and 3D maps.