### PR TITLE
Refactor: Change 2D historical ISS path to solid line

### DIFF
--- a/views/earth.ejs
+++ b/views/earth.ejs
@@ -363,8 +363,7 @@ function displayHistoricalDataOn2DMap(historicalPoints) {
     if (latLngs.length > 1 && mymap) {
         historicalIssPathPolyline = L.polyline(latLngs, {
             color: 'orange', // Different color for historical path
-            weight: 3,
-            dashArray: '5, 5' // Dashed line for distinction
+            weight: 3
         }).addTo(mymap);
         console.log('[Historical Path] Historical ISS path drawn on 2D map with', latLngs.length, 'points.');
     } else {


### PR DESCRIPTION
This commit updates the styling of the historical ISS path on the 2D Leaflet map in `views/earth.ejs`.

Based on your feedback, the `dashArray` property has been removed from the polyline options in the `displayHistoricalDataOn2DMap` function. This changes the line from dashed to solid, while retaining its orange color and weight of 3 for clear visual distinction from the live ISS track.