### PR TITLE
feat: Replace p5.js 3D Earth with three.js implementation

### DIFF
--- a/public/js/threeEarth.js
+++ b/public/js/threeEarth.js
@@ -1,0 +1,280 @@
+// public/js/threeEarth.js
+
+// Ensure this script runs after the DOM is fully loaded
+document.addEventListener('DOMContentLoaded', () => {
+
+    // Check if three.js is loaded
+    if (typeof THREE === 'undefined') {
+        console.error('THREE.js not loaded. Ensure it is included before this script.');
+        return;
+    }
+
+    let scene, camera, renderer, earthMesh, issMesh, clientMesh;
+    let issPathMeshes = [];
+    let earthquakeMeshes = [];
+    const sketchHolder = document.getElementById('sketch-holder');
+
+    // ISS data (will be updated from global scope)
+    // let iss = window.iss; // Access global iss variable
+
+    // Client location data (will be updated from global scope)
+    // let clientLat = window.clientLat;
+    // let clientLon = window.clientLon;
+
+    // Earthquake data (will be accessed from global scope or loaded)
+    // let earthquakes = window.earthquakes;
+
+    const EARTH_RADIUS = 300; // Consistent with p5.js version's earthSize
+    const ISS_ALTITUDE = 50; // Consistent with p5.js version's issDistanceToEarth
+    const GPS_MARKER_SIZE = 5;
+    const ISS_MARKER_SIZE = 10; // Adjust as needed
+    const ISS_PATH_POINT_SIZE = 2;
+
+    function init() {
+        // Scene
+        scene = new THREE.Scene();
+
+        // Camera
+        const fov = 75;
+        const aspect = sketchHolder.offsetWidth / sketchHolder.offsetHeight;
+        const near = 0.1;
+        const far = 5000; // Increased far plane for skybox/stars if added later
+        camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
+        camera.position.z = EARTH_RADIUS * 2; // Initial camera distance
+
+        // Renderer
+        renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setSize(sketchHolder.offsetWidth, sketchHolder.offsetHeight);
+        renderer.setClearColor(0x343434); // Similar to p5.js background(52)
+        sketchHolder.appendChild(renderer.domElement);
+
+        // Lighting
+        const ambientLight = new THREE.AmbientLight(0xffffff, 0.8); // Softer ambient light
+        scene.add(ambientLight);
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 1); // Brighter directional
+        directionalLight.position.set(5, 3, 5); // Adjust position as needed
+        scene.add(directionalLight);
+
+        // OrbitControls
+        if (typeof THREE.OrbitControls !== 'undefined') {
+            const controls = new THREE.OrbitControls(camera, renderer.domElement);
+            controls.enableDamping = true;
+            controls.dampingFactor = 0.05;
+            controls.screenSpacePanning = false;
+            controls.minDistance = EARTH_RADIUS / 2;
+            controls.maxDistance = EARTH_RADIUS * 4;
+            controls.update(); // Required after property changes
+        } else {
+            console.warn('THREE.OrbitControls not loaded.');
+        }
+
+        // Earth
+        const earthTextureLoader = new THREE.TextureLoader();
+        earthTextureLoader.load('/img/cloudyEarth.jpg', (texture) => {
+            const earthGeometry = new THREE.SphereGeometry(EARTH_RADIUS, 64, 64); // Increased segments for smoother sphere
+            const earthMaterial = new THREE.MeshStandardMaterial({ map: texture, metalness: 0.3, roughness: 0.7 });
+            earthMesh = new THREE.Mesh(earthGeometry, earthMaterial);
+            scene.add(earthMesh);
+        });
+
+        // Initial placeholder for ISS - will be updated
+        const issTextureLoader = new THREE.TextureLoader();
+        issTextureLoader.load('/img/iss.png', (texture) => {
+            // Using a Sprite for ISS so it always faces the camera and can be scaled easily
+            const issMaterial = new THREE.SpriteMaterial({ map: texture, transparent: true, alphaTest: 0.5 });
+            issMesh = new THREE.Sprite(issMaterial);
+            const issScale = ISS_MARKER_SIZE * 5; // Adjust scale as needed for sprite
+            issMesh.scale.set(issScale, issScale, issScale);
+            issMesh.visible = false; // Initially hidden until position is known
+            scene.add(issMesh);
+        });
+
+
+        // Handle window resize
+        window.addEventListener('resize', onWindowResize, false);
+
+        // Start animation loop
+        animate();
+    }
+
+    function getSphereCoordinates(radius, latitude, longitude) {
+        const latRad = THREE.MathUtils.degToRad(latitude);
+        const lonRad = THREE.MathUtils.degToRad(longitude);
+
+        // p5.js derived conversion (matches Tools.p5.getSphereCoord)
+        // phi corresponds to longitude, theta to latitude
+        const phi = lonRad + Math.PI; // Longitude adjustment from p5.js
+        const theta = latRad;         // Latitude
+
+        const x = radius * Math.cos(theta) * Math.cos(phi);
+        const y = -radius * Math.sin(theta); // Negative y for p5.js consistency
+        const z = -radius * Math.cos(theta) * Math.sin(phi); // Negative z part of the conversion
+
+        return new THREE.Vector3(x, y, z);
+    }
+
+    // Placeholder for client marker logic
+    function updateClientMarker() {
+        if (typeof window.clientLat !== 'undefined' && window.clientLat !== null &&
+            typeof window.clientLon !== 'undefined' && window.clientLon !== null) {
+            if (!clientMesh) {
+                const clientGeometry = new THREE.SphereGeometry(GPS_MARKER_SIZE, 16, 16);
+                const clientMaterial = new THREE.MeshBasicMaterial({ color: 0xffff00 }); // Yellow
+                clientMesh = new THREE.Mesh(clientGeometry, clientMaterial);
+                scene.add(clientMesh);
+            }
+            const clientPosition = getSphereCoordinates(EARTH_RADIUS + 1, window.clientLat, window.clientLon); // Slightly above surface
+            clientMesh.position.copy(clientPosition);
+
+            // Rotate mesh to "point away" from earth center (useful if it's a cone/arrow later)
+            clientMesh.lookAt(earthMesh.position); // Makes the marker's local -Z axis point to Earth's center
+            clientMesh.rotateX(Math.PI / 2); // Adjust if the marker has a specific "up"
+
+        } else if (clientMesh) {
+            clientMesh.visible = false;
+        }
+    }
+
+
+    // Placeholder for ISS update logic
+    let internalIssPathHistory = []; // To store THREE.Vector3 positions
+    const MAX_ISS_HISTORY_POINTS = 1500; // Match p5.js
+
+    function updateISS() {
+        if (typeof window.iss !== 'undefined' && window.iss &&
+            typeof window.iss.latitude !== 'undefined' && typeof window.iss.longitude !== 'undefined') {
+
+            if (!issMesh || !earthMesh) return; // Ensure meshes are loaded
+
+            const issPosition = getSphereCoordinates(EARTH_RADIUS + ISS_ALTITUDE, window.iss.latitude, window.iss.longitude);
+            issMesh.position.copy(issPosition);
+            issMesh.visible = true;
+
+            // Update ISS path history
+            // Avoid adding duplicate points if ISS data hasn't changed significantly
+            if (internalIssPathHistory.length === 0 || internalIssPathHistory[internalIssPathHistory.length - 1].distanceToSquared(issPosition) > 0.1) {
+                internalIssPathHistory.push(issPosition.clone());
+                if (internalIssPathHistory.length > MAX_ISS_HISTORY_POINTS) {
+                    internalIssPathHistory.shift(); // Remove the oldest point
+                }
+
+                // Update path visualization
+                // Simple: clear and redraw all path points (can be optimized later)
+                issPathMeshes.forEach(mesh => scene.remove(mesh));
+                issPathMeshes = [];
+
+                const pathMaterial = new THREE.MeshBasicMaterial({ color: 0xffa500 }); // Orange
+                const pathGeometry = new THREE.SphereGeometry(ISS_PATH_POINT_SIZE, 8, 8);
+
+                for (let i = 0; i < internalIssPathHistory.length; i++) {
+                    const pointMesh = new THREE.Mesh(pathGeometry, pathMaterial);
+                    pointMesh.position.copy(internalIssPathHistory[i]);
+                    scene.add(pointMesh);
+                    issPathMeshes.push(pointMesh);
+                }
+            }
+        } else if (issMesh) {
+            issMesh.visible = false;
+        }
+    }
+
+    // Placeholder for earthquake loading and display
+    async function loadAndDisplayEarthquakes() {
+        if (typeof window.earthquakesData !== 'undefined' && window.earthquakesData) { // Check if data is already loaded by earthThreeJS.ejs
+             displayEarthquakes(window.earthquakesData);
+        } else {
+            try {
+                const response = await fetch('/data/quakes.csv');
+                if (!response.ok) {
+                    console.error('Failed to fetch earthquake data:', response.statusText);
+                    return;
+                }
+                const csvData = await response.text();
+                const lines = csvData.split('\n').slice(1); // Skip header line
+                const quakes = lines.map(line => {
+                    const parts = line.split(',');
+                    if (parts.length >= 5) { // Ensure enough data fields
+                        return { lat: parseFloat(parts[1]), lon: parseFloat(parts[2]), mag: parseFloat(parts[4]) };
+                    }
+                    return null;
+                }).filter(q => q && !isNaN(q.lat) && !isNaN(q.lon) && !isNaN(q.mag)); // Filter out invalid entries
+
+                window.earthquakesData = quakes; // Cache for future use
+                displayEarthquakes(quakes);
+
+            } catch (error) {
+                console.error('Error loading or parsing earthquake data:', error);
+            }
+        }
+    }
+
+    function displayEarthquakes(quakesData) {
+        if (!earthMesh) return; // Ensure Earth mesh is loaded
+
+        // Clear existing earthquake meshes
+        earthquakeMeshes.forEach(mesh => scene.remove(mesh));
+        earthquakeMeshes = [];
+
+        const baseQuakeSize = 1;
+        const maxMagnitudeEffect = 20; // Max size added for largest quakes
+
+        for (const quake of quakesData) {
+            const quakePosition = getSphereCoordinates(EARTH_RADIUS, quake.lat, quake.lon);
+
+            // Scale magnitude: Example mapping, adjust as needed
+            const magnitudeScale = Math.max(0, Math.min(1, (quake.mag + 1) / 11)); // Normalize from ~-1 to 10 -> 0 to 1
+            const quakeMarkerSize = baseQuakeSize + magnitudeScale * maxMagnitudeEffect;
+
+            const fromColor = new THREE.Color(0x00ff00); // Green for low magnitude
+            const toColor = new THREE.Color(0xff0000);   // Red for high magnitude
+            const quakeColor = new THREE.Color().lerpColors(fromColor, toColor, magnitudeScale);
+
+            const quakeGeometry = new THREE.SphereGeometry(quakeMarkerSize, 12, 12);
+            const quakeMaterial = new THREE.MeshBasicMaterial({ color: quakeColor });
+            const quakeMeshInstance = new THREE.Mesh(quakeGeometry, quakeMaterial);
+            quakeMeshInstance.position.copy(quakePosition);
+
+            // Orient the quake marker (e.g., if it were a cylinder/bar)
+            quakeMeshInstance.lookAt(earthMesh.position);
+
+            scene.add(quakeMeshInstance);
+            earthquakeMeshes.push(quakeMeshInstance);
+        }
+    }
+
+
+    function onWindowResize() {
+        if (camera && renderer && sketchHolder) {
+            camera.aspect = sketchHolder.offsetWidth / sketchHolder.offsetHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(sketchHolder.offsetWidth, sketchHolder.offsetHeight);
+        }
+    }
+
+    function animate() {
+        requestAnimationFrame(animate);
+
+        if (earthMesh) {
+            // Consistent rotation speed with p5.js (Math.PI * 2 / 60 seconds)
+            // millis() / 1000 * rotationSpeed
+            // (Date.now() / 1000) * (Math.PI * 2 / 60)
+            earthMesh.rotation.y = (Date.now() / 1000) * (Math.PI / 30); // Rotation speed
+        }
+
+        updateISS(); // Update ISS position and path
+        updateClientMarker(); // Update client marker position
+
+        if (typeof THREE.OrbitControls !== 'undefined' && camera.controls) { // Check if controls exist
+            camera.controls.update(); // Only required if controls.enableDamping or controls.autoRotate are set to true
+        }
+
+        if (renderer && scene && camera) {
+             renderer.render(scene, camera);
+        }
+    }
+
+    // Initialize everything
+    init();
+    loadAndDisplayEarthquakes(); // Load earthquake data
+
+});

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -184,7 +184,7 @@ router.get('/iot',  async (req, res) =>
 
 
 router.get('/earth', async (req, res) => {
-    res.render('earth')
+    res.render('earthThreeJS')
 })
 
 router.get('/natureCode', (req, res) => {

--- a/views/earthThreeJS.ejs
+++ b/views/earthThreeJS.ejs
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+        <%- include('partials/mainHead', { title: 'SBQC ' }) %>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"    integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="    crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"    integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="    crossorigin=""></script>
+        <style>
+            .arrow {
+                width: 0;
+                height: 0;
+                border-left: 10px solid transparent;
+                border-right: 10px solid transparent;
+                border-bottom: 20px solid black;
+                transform-origin: center;
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%) rotate(0deg);
+            }
+
+            .wind-container {
+                position: relative;
+                width: 100px;
+                height: 100px;
+                margin: 0 auto;
+            }
+
+            .cardinal-points {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                pointer-events: none;
+            }
+
+            .cardinal-points .north {
+                position: absolute;
+                top: 0;
+                left: 50%;
+                transform: translateX(-50%);
+            }
+
+            .cardinal-points .east {
+                position: absolute;
+                top: 50%;
+                right: 0;
+                transform: translateY(-50%);
+            }
+
+            .cardinal-points .south {
+                position: absolute;
+                bottom: 0;
+                left: 50%;
+                transform: translateX(-50%);
+            }
+
+            .cardinal-points .west {
+                position: absolute;
+                top: 50%;
+                left: 0;
+                transform: translateY(-50%);
+            }
+            </style>
+
+    </head>
+
+
+<body class="fixed-nav sticky-footer bg-light sidenav-toggled" id="page-top">
+
+<%- include('partials/nav') %>
+
+<div class="content-wrapper">
+<div class="container-fluid bg-3 text-center">
+<!-- Begin Container  -->
+
+<div class="card mb-3">
+    <div class="card-body">
+        <div class="row">
+            <div class="col-6">
+                <div class="wind-container">
+                    <div id="wind-arrow" class="arrow"></div>
+                    <div class="cardinal-points">
+                        <div class="north">N</div>
+                        <div class="east">E</div>
+                        <div class="south">S</div>
+                        <div class="west">W</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6">
+                <div>Speed: <span id="wind-speed"></span> m/s</div>
+                <div>Gust: <span id="wind-gust"></span> m/s</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        <p>
+            At location: <span id="summary"></span> with a temperature of <span id="temp"></span>&deg; C. <br>
+            Concentration of particulate matter - (<span id="aq_parameter"></span>) <span id="aq_value"></span> <span id="aq_units"></span> <br>
+            <small> Last read on <span id="aq_date"></span></small>
+        </p>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <p>Next ISS pass-by: <span id="iss-passby-time">Calculating...</span></p>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+                <div class="card-title">3D Viewer</div>
+                <div class="card-body" >
+                        <div id="sketch-holder">
+                </div>
+                <div class="card-footer small text-muted">Press 's' to save canvas to png  </div>
+        </div>
+
+        <div class="card mb-3">
+                <div class="card-body" >
+                        <p>ISS location -  lat: <span id="isslat"></span>&deg; lon: <span id="isslon"></span>&deg; </p>
+                        <p>Client location -  lat: <span id="clat"></span>&deg; lon: <span id="clon"></span>&deg;</span> </p>
+                        <p id="default-location-msg" style="font-size: 0.8em; color: #777; display: none;">Using default location as live geolocation is unavailable.</p>
+                        <div id='issMap' style="height:720px;"></div>
+                </div>
+                <div class="card-footer small text-muted"> <a href="https://eyes.nasa.gov/apps/solar-system/#/home" target="_blank" class="btn btn-outline-primary">Explore with NASA Eyes</a> </div>
+        </div>
+
+<!-- End Container  -->
+</div>
+</div>
+</div>
+<div id="ip_id"></div>
+
+<%- include('partials/footer') %>
+<%- include('partials/p5') %>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+<script src="/js/threeEarth.js"></script>
+
+<script>
+
+let iss;   // International Space Station location
+let clientLat = null;
+let clientLon = null;
+
+// For 2D path
+let issPathHistory = [];
+const MAX_2D_HISTORY_POINTS = 1500;
+let issPathPolyline = null; // Live ISS path
+let historicalIssPathPolyline = null; // Historical ISS path from initial load
+let mymap; // Declare mymap globally
+
+// For Predicted Path
+let predictedIssPathPoints = [];
+let predictedIssPathPolyline = null;
+
+// For pass-by estimation
+let lastPassByCheckTime = 0;
+const PASS_BY_CHECK_INTERVAL = 30000; // 30 seconds
+const PASS_BY_THRESHOLD_KM = 1000; // Max distance for a "close" pass
+
+let socket = io();
+
+socket.on('connect', () => {
+    console.log('Connected to server');
+});
+
+socket.on('iss', (data) => {
+    iss = data; // iss is used by earth3D.js globally
+
+    issPathHistory.push({lat: iss.latitude, lng: iss.longitude, timestamp: Date.now()});
+    if (issPathHistory.length > MAX_2D_HISTORY_POINTS) {
+        issPathHistory.shift();
+    }
+    updateIssOnMap(iss.latitude, iss.longitude); // This will also update predicted path display
+
+    const now = Date.now();
+    if (clientLat !== null && clientLon !== null && now - lastPassByCheckTime > PASS_BY_CHECK_INTERVAL) {
+        calculateAndDisplayPassBy();
+        // updateIssOnMap() is called above, which will refresh the predicted path if it changed
+        lastPassByCheckTime = now;
+    }
+});
+
+function setMap() {
+    mymap = L.map('issMap').setView([0, 0], 1);
+    const attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+    const tileUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    const tiles = L.tileLayer(tileUrl, { attribution });
+    tiles.addTo(mymap);
+
+    const issIcon = L.icon({
+        iconUrl: 'img/iss.png',
+        iconSize: [50, 32],
+        iconAnchor: [25, 16]
+    });
+
+    let clientMarkerInstance = L.marker([0, 0]).addTo(mymap);
+    let issMarkerInstance = L.marker([0, 0], { icon: issIcon }).addTo(mymap);
+
+    mymap.on('zoomend', function() {
+        const zoom = mymap.getZoom() + 1;
+        const w = 50 * zoom;
+        const h = 32 * zoom;
+        issIcon.options.iconSize = [w, h];
+        issIcon.options.iconAnchor = [w / 2, h / 2];
+        mymap.removeLayer(issMarkerInstance);
+        let latlng = issMarkerInstance.getLatLng();
+        issMarkerInstance = L.marker([0,0], {icon: issIcon}).addTo(mymap);
+        issMarkerInstance.setLatLng(latlng);
+    });
+
+    window.clientMarker = clientMarkerInstance;
+    window.issMarker = issMarkerInstance;
+
+    return { mymap_local: mymap, clientMarker_local: clientMarkerInstance, issMarker_local: issMarkerInstance };
+}
+
+const mapSetUp = setMap();
+
+function setClientMarker(lat, lon) {
+    if (window.clientMarker) {
+        window.clientMarker.setLatLng([lat, lon]);
+        if (mymap) {
+            mymap.setView([lat, lon], 5);
+        }
+    }
+    clientLat = lat;
+    clientLon = lon;
+}
+
+async function fetchWeatherForCoords(lat, lon) {
+    const url =`api/weather/${lat},${lon}`;
+    try {
+        const response = await fetch(url);
+        const data = await response.json();
+
+        document.getElementById('summary').textContent = data.weather.weather[0].description;
+        document.getElementById('temp').textContent =  data.weather.main.feels_like;
+        if (data.air_quality && data.air_quality.results && data.air_quality.results[0]) {
+            const air = data.air_quality.results[0];
+            document.getElementById('aq_parameter').textContent = air.parameter.displayName;
+            document.getElementById('aq_value').textContent = air.latest.value;
+            document.getElementById('aq_units').textContent = air.parameter.units;
+            document.getElementById('aq_date').textContent = air.latest.datetime.local;
+        } else {
+             document.getElementById('aq_value').textContent = 'NO READING';
+        }
+        const wind = data.weather.wind;
+        document.getElementById('wind-speed').textContent = wind.speed;
+        document.getElementById('wind-gust').textContent = wind.gust;
+        document.getElementById('wind-arrow').style.transform = `rotate(${wind.deg}deg)`;
+
+    } catch (e) {
+        Tools.cliError(e);
+        document.getElementById('aq_value').textContent = 'NO READING';
+    }
+}
+
+async function setDefaultLocationAndFetchWeather() {
+    console.log("Using default client location.");
+    clientLat = 46.82;
+    clientLon = -71.30;
+
+    document.getElementById('clat').textContent = clientLat.toFixed(2);
+    document.getElementById('clon').textContent = clientLon.toFixed(2);
+    document.getElementById('default-location-msg').style.display = 'block';
+
+    setClientMarker(clientLat, clientLon);
+    await fetchWeatherForCoords(clientLat, clientLon);
+}
+
+async function updateGeoData() {
+    try {
+        console.log("Attempting to get live geolocation...");
+        const {coords} = await Tools.geoLocate();
+        clientLat = coords.latitude;
+        clientLon = coords.longitude;
+        console.log("Live geolocation successful:", clientLat, clientLon);
+        document.getElementById('default-location-msg').style.display = 'none';
+
+        document.getElementById('clat').textContent = clientLat.toFixed(2);
+        document.getElementById('clon').textContent = clientLon.toFixed(2);
+
+        setClientMarker(clientLat, clientLon);
+        await fetchWeatherForCoords(clientLat, clientLon);
+
+    } catch(e) {
+        console.warn('Error getting live geolocation or permission denied:', e.message);
+        alert('Live geolocation failed. Using default location (Quebec City area). Error: '+e.message);
+        await setDefaultLocationAndFetchWeather();
+    }
+}
+
+if (Tools.isGeoLocAvailable()) {
+    updateGeoData();
+} else {
+    console.log("Geolocation not available in this browser, using default location.");
+    setDefaultLocationAndFetchWeather();
+}
+
+let firstTime = true;
+
+async function updateIssOnMap(lat, lon) {
+    if (window.issMarker) {
+         window.issMarker.setLatLng([lat, lon]);
+    } else {
+        console.warn("ISS marker not initialized for updateIssOnMap");
+        return;
+    }
+
+    if (firstTime && mymap) {
+        if (clientLat === null) {
+             mymap.setView([lat, lon], 2);
+        }
+        firstTime = false;
+    }
+
+    document.getElementById('isslat').textContent = parseFloat(lat).toFixed(2);
+    document.getElementById('isslon').textContent = parseFloat(lon).toFixed(2);
+
+    // Draw historical path
+    if (issPathPolyline && mymap) {
+        mymap.removeLayer(issPathPolyline);
+    }
+    const latLngs = issPathHistory.map(p => [p.lat, p.lng]);
+    if (latLngs.length > 1 && mymap) {
+        issPathPolyline = L.polyline(latLngs, { color: 'blue', weight: 5 }).addTo(mymap);
+    }
+
+    // Draw predicted path
+    if (predictedIssPathPolyline && mymap) {
+        mymap.removeLayer(predictedIssPathPolyline);
+        predictedIssPathPolyline = null;
+    }
+    if (predictedIssPathPoints && predictedIssPathPoints.length > 1 && mymap) {
+        const predictedLatLngs = predictedIssPathPoints.map(p => [p.lat, p.lng]);
+        predictedIssPathPolyline = L.polyline(predictedLatLngs, {
+            color: 'green',
+            weight: 3,
+            dashArray: '5, 10'
+        }).addTo(mymap);
+    }
+}
+
+function displayHistoricalDataOn2DMap(historicalPoints) {
+    console.log('[Historical Path] displayHistoricalDataOn2DMap called with', historicalPoints.length, 'points.');
+
+    if (historicalIssPathPolyline && mymap) {
+        mymap.removeLayer(historicalIssPathPolyline);
+        console.log('[Historical Path] Removed existing historical polyline from 2D map.');
+    }
+
+    if (!historicalPoints || historicalPoints.length === 0) {
+        console.log('[Historical Path] No points provided or empty array, historical path will not be drawn.');
+        historicalIssPathPolyline = null; // Ensure it's cleared if no points
+        return;
+    }
+
+    const latLngs = historicalPoints.map(p => [p.lat, p.lon]); // Note: earth3D.js uses p.lon
+
+    if (latLngs.length > 1 && mymap) {
+        historicalIssPathPolyline = L.polyline(latLngs, {
+            color: 'orange', // Different color for historical path
+            weight: 3
+        }).addTo(mymap);
+        console.log('[Historical Path] Historical ISS path drawn on 2D map with', latLngs.length, 'points.');
+    } else {
+        console.log('[Historical Path] Not enough points to draw historical ISS path on 2D map (need > 1) or mymap not ready. Points:', latLngs.length);
+        historicalIssPathPolyline = null; // Ensure it's cleared if not drawn
+    }
+}
+
+function calculateAndDisplayPassBy() {
+    const passByStatus = document.getElementById('iss-passby-time');
+    console.log('[PassByDebug] calculateAndDisplayPassBy called.');
+    // console.log('[PassByDebug] Client Coords:', clientLat, clientLon); // Already logged by caller or initial setup
+    // console.log('[PassByDebug] ISS History Length:', issPathHistory.length);
+    // console.log('[PassByDebug] Tools.haversineDistance available:', typeof Tools.haversineDistance === 'function');
+
+    if (!clientLat || !clientLon) {
+        passByStatus.textContent = 'Waiting for client location...';
+        predictedIssPathPoints = [];
+        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        console.log('[PassByDebug] Returning: Client location not available.');
+        return;
+    }
+    if (issPathHistory.length < 2) {
+        passByStatus.textContent = 'Insufficient ISS path data...';
+        predictedIssPathPoints = [];
+        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        console.log('[PassByDebug] Returning: Insufficient ISS path data.');
+        return;
+    }
+    if (typeof Tools.haversineDistance !== 'function') {
+        passByStatus.textContent = 'Distance calculation tool not available.';
+        predictedIssPathPoints = [];
+        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        console.error('[PassByDebug] Returning: Tools.haversineDistance is not a function.');
+        return;
+    }
+
+    passByStatus.textContent = 'Calculating...';
+    // console.log('[PassByDebug] Proceeding with calculation...');
+
+    const lastPoint = issPathHistory[issPathHistory.length - 1];
+    const secondLastPoint = issPathHistory[issPathHistory.length - 2];
+    // console.log('[PassByDebug] lastPoint:', lastPoint, 'secondLastPoint:', secondLastPoint);
+
+    const timeDiffSeconds = (lastPoint.timestamp - secondLastPoint.timestamp) / 1000;
+    // console.log('[PassByDebug] timeDiffSeconds:', timeDiffSeconds);
+
+    if (timeDiffSeconds <= 0) {
+        passByStatus.textContent = 'Static or invalid ISS data timestamps.';
+        predictedIssPathPoints = [];
+        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        console.log('[PassByDebug] Returning: Static or invalid ISS data timestamps.');
+        return;
+    }
+
+    const latSpeed = (lastPoint.lat - secondLastPoint.lat) / timeDiffSeconds;
+    const lonSpeed = (lastPoint.lng - secondLastPoint.lng) / timeDiffSeconds;
+    // console.log('[PassByDebug] latSpeed:', latSpeed, 'lonSpeed:', lonSpeed);
+
+    let minFutureDist = Infinity;
+    let timeOfClosestApproach = null;
+    let tempPredictedPath = [];
+    predictedIssPathPoints = []; // Clear global predicted path at start of this calculation run
+
+    // console.log('[PassByDebug] Starting extrapolation loop for predicted path...');
+    for (let t = 0; t < 7200; t += 30) {
+        const futureLat = lastPoint.lat + latSpeed * t;
+        const futureLon = lastPoint.lng + lonSpeed * t;
+        const normalizedFutureLon = (futureLon + 540) % 360 - 180;
+
+        tempPredictedPath.push({lat: futureLat, lng: normalizedFutureLon});
+
+        const dist = Tools.haversineDistance(clientLat, clientLon, futureLat, normalizedFutureLon);
+        if (dist < minFutureDist) {
+            minFutureDist = dist;
+            timeOfClosestApproach = t;
+            if (minFutureDist < PASS_BY_THRESHOLD_KM) {
+                 predictedIssPathPoints = tempPredictedPath.slice(0, tempPredictedPath.length);
+            }
+        }
+    }
+
+    if (!(minFutureDist < PASS_BY_THRESHOLD_KM && timeOfClosestApproach !== null)) {
+        predictedIssPathPoints = [];
+    }
+    // console.log('[PassByDebug] Extrapolation loop finished. Stored predicted points:', predictedIssPathPoints.length);
+
+    if (minFutureDist < PASS_BY_THRESHOLD_KM && timeOfClosestApproach !== null) {
+        const approachDate = new Date(Date.now() + timeOfClosestApproach * 1000);
+        passByStatus.textContent = `Approx. pass at ${approachDate.toLocaleTimeString()} (distance ~${minFutureDist.toFixed(0)} km).`;
+    } else {
+        passByStatus.textContent = `No close pass predicted soon (closest ~${minFutureDist.toFixed(0)}km).`;
+    }
+
+    if (iss && typeof iss.latitude !== 'undefined') {
+         updateIssOnMap(iss.latitude, iss.longitude);
+    } else if (issPathHistory.length > 0) {
+        const lastKnownIss = issPathHistory[issPathHistory.length -1];
+        updateIssOnMap(lastKnownIss.lat, lastKnownIss.lng);
+    }
+}
+
+async function getUserInfo() {
+    const info = await Tools.ipLookUp();
+    document.getElementById('ip_id').innerHTML =  "<pre>"+JSON.stringify(info,null, '\t') +"</pre>";
+}
+getUserInfo();
+
+setTimeout(() => {
+    console.log('[PassByDebug] Initial timeout for calculateAndDisplayPassBy.');
+    if (clientLat !== null && clientLon !== null && issPathHistory.length > 1) {
+        calculateAndDisplayPassBy();
+    } else {
+        console.log('[PassByDebug] Conditions not met for initial pass-by calculation.');
+         document.getElementById('iss-passby-time').textContent = 'Waiting for initial data...';
+    }
+}, 5000);
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
- I created a new view 'earthThreeJS.ejs' by duplicating 'earth.ejs'.
- I modified 'earthThreeJS.ejs' to remove the p5.js 3D globe script ('earth3D.js') and include three.js library and a new 'threeEarth.js' script.
- I developed 'public/js/threeEarth.js' which renders a 3D Earth globe using three.js:
    - Displays Earth with texture and rotation.
    - Shows ISS position and historical path based on live data.
    - Visualizes earthquake data on the globe.
    - Marks your current latitude/longitude.
    - Implements a coordinate conversion utility to map lat/lon to sphere points, consistent with the previous p5.js version.
    - Includes OrbitControls for camera manipulation.
- I updated 'routes/routes.js' to make the '/earth' path render the new 'earthThreeJS.ejs' view.

This change migrates the 3D Earth visualization to three.js, allowing for potentially more advanced 3D features in the future, while retaining the existing 2D map and informational layout of the page.