### PR TITLE
Fix: Use historical data for initial prediction & update slider max

### DIFF
--- a/views/earth.ejs
+++ b/views/earth.ejs
@@ -142,7 +142,7 @@
                             <!-- New Prediction Length Slider -->
                             <div style="margin-top: 10px;">
                                 <label for="predictionLengthSlider">Prediction Length: <span id="predictionLengthValue">15</span> min</label>
-                                <input type="range" id="predictionLengthSlider" min="5" max="120" step="5" value="15" style="width: 100%;">
+                                <input type="range" id="predictionLengthSlider" min="5" max="360" step="5" value="15" style="width: 100%;">
                             </div>
 
                             <!-- New Pass-by Radius Slider -->
@@ -424,53 +424,80 @@ function displayHistoricalDataOn2DMap(historicalPoints) {
 function calculateAndDisplayPassBy() {
     const passByStatus = document.getElementById('iss-passby-time');
     console.log('[PassByDebug] calculateAndDisplayPassBy called.');
-    // console.log('[PassByDebug] Client Coords:', clientLat, clientLon); // Already logged by caller or initial setup
-    // console.log('[PassByDebug] ISS History Length:', issPathHistory.length);
-    // console.log('[PassByDebug] Tools.haversineDistance available:', typeof Tools.haversineDistance === 'function');
 
     if (!clientLat || !clientLon) {
         passByStatus.textContent = 'Waiting for client location...';
         predictedIssPathPoints = [];
-        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        if (typeof window.update3DPredictedPath === 'function') window.update3DPredictedPath(predictedIssPathPoints);
+        // Conditional map update based on available data
+        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude);
+        else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
         console.log('[PassByDebug] Returning: Client location not available.');
         return;
     }
+
+    let basePathForPrediction = issPathHistory; // Default to live data
+    let usingHistoricalDataForPrediction = false;
+
     if (issPathHistory.length < 2) {
-        passByStatus.textContent = 'Insufficient ISS path data...';
-        predictedIssPathPoints = [];
-        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
-        console.log('[PassByDebug] Returning: Insufficient ISS path data.');
-        return;
+        console.log('[PassByDebug] Live ISS path history too short, attempting to use historical data for prediction.');
+        if (typeof window.internalIssPathHistory !== 'undefined' && window.internalIssPathHistory.length >= 2) {
+            basePathForPrediction = window.internalIssPathHistory;
+            usingHistoricalDataForPrediction = true;
+            console.log('[PassByDebug] Using historical data for prediction. Points:', basePathForPrediction.length);
+        } else {
+            console.log('[PassByDebug] Historical data also too short or unavailable for prediction.');
+            passByStatus.textContent = 'Insufficient ISS path data (live or historical)...';
+            predictedIssPathPoints = [];
+            if (typeof window.update3DPredictedPath === 'function') {
+                 window.update3DPredictedPath(predictedIssPathPoints);
+            }
+            if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude);
+            else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+            return;
+        }
+    } else {
+        console.log('[PassByDebug] Using live ISS path history for prediction. Points:', basePathForPrediction.length);
     }
+
     if (typeof Tools.haversineDistance !== 'function') {
         passByStatus.textContent = 'Distance calculation tool not available.';
         predictedIssPathPoints = [];
-        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
+        if (typeof window.update3DPredictedPath === 'function') window.update3DPredictedPath(predictedIssPathPoints);
         console.error('[PassByDebug] Returning: Tools.haversineDistance is not a function.');
         return;
     }
 
     passByStatus.textContent = 'Calculating...';
-    // console.log('[PassByDebug] Proceeding with calculation...');
 
-    const lastPoint = issPathHistory[issPathHistory.length - 1];
-    const secondLastPoint = issPathHistory[issPathHistory.length - 2];
-    // console.log('[PassByDebug] lastPoint:', lastPoint, 'secondLastPoint:', secondLastPoint);
+    let lastPoint, secondLastPoint, timeDiffSeconds;
 
-    const timeDiffSeconds = (lastPoint.timestamp - secondLastPoint.timestamp) / 1000;
-    // console.log('[PassByDebug] timeDiffSeconds:', timeDiffSeconds);
+    if (usingHistoricalDataForPrediction) {
+        const p1 = basePathForPrediction[basePathForPrediction.length - 1]; // Newest point from historical
+        const p2 = basePathForPrediction[basePathForPrediction.length - 2]; // Second newest
+        lastPoint = { lat: p1.lat, lng: p1.lon }; // Adapt .lon to .lng
+        secondLastPoint = { lat: p2.lat, lng: p2.lon };
+        // Assuming historical points from API are roughly 5 seconds apart.
+        // This is a placeholder; ideally, populateInitialIssHistory in earth3D.js would store actual timestamps.
+        timeDiffSeconds = 5.0;
+        console.log('[PassByDebug] Using historical data, assumed timeDiffSeconds: 5s. Accuracy may vary.');
+    } else { // Using live issPathHistory
+        lastPoint = basePathForPrediction[basePathForPrediction.length - 1];
+        secondLastPoint = basePathForPrediction[basePathForPrediction.length - 2];
+        timeDiffSeconds = (lastPoint.timestamp - secondLastPoint.timestamp) / 1000;
+    }
 
     if (timeDiffSeconds <= 0) {
-        passByStatus.textContent = 'Static or invalid ISS data timestamps.';
+        passByStatus.textContent = 'Static or invalid ISS data timestamps for speed calculation.';
         predictedIssPathPoints = [];
-        if (window.issMarker && typeof iss !== 'undefined' && iss) updateIssOnMap(iss.latitude, iss.longitude); else if (issPathHistory.length > 0) updateIssOnMap(issPathHistory[issPathHistory.length-1].lat, issPathHistory[issPathHistory.length-1].lng);
-        console.log('[PassByDebug] Returning: Static or invalid ISS data timestamps.');
+        if (typeof window.update3DPredictedPath === 'function') window.update3DPredictedPath(predictedIssPathPoints);
+        console.log('[PassByDebug] Returning: Time difference issue for speed calculation.');
+        // updateIssOnMap might not be helpful here as path is not changing.
         return;
     }
 
     const latSpeed = (lastPoint.lat - secondLastPoint.lat) / timeDiffSeconds;
-    const lonSpeed = (lastPoint.lng - secondLastPoint.lng) / timeDiffSeconds;
-    // console.log('[PassByDebug] latSpeed:', latSpeed, 'lonSpeed:', lonSpeed);
+    const lonSpeed = (lastPoint.lng - secondLastPoint.lng) / timeDiffSeconds; // Ensure .lng is used
 
     let minFutureDist = Infinity;
     let timeOfClosestApproach = null;


### PR DESCRIPTION
This commit addresses your feedback regarding the ISS prediction path:

1.  **Updated Prediction Length Slider Max Value:**
    - In `views/earth.ejs`, the `max` attribute of the "Prediction Length" slider (`predictionLengthSlider`) was increased from 120 minutes to 360 minutes (6 hours), allowing you to request longer prediction lines.

2.  **Utilize Historical Data for Initial Prediction:**
    - Modified the `calculateAndDisplayPassBy` function in `views/earth.ejs`.
    - The function now checks if sufficient live ISS data (`issPathHistory`) is available (at least 2 points) to make a prediction.
    - If live data is insufficient, it attempts to use the initially loaded historical data (`window.internalIssPathHistory` from `public/js/earth3D.js`) as a fallback.
    - When using historical data (which currently doesn't store individual timestamps per point in `internalIssPathHistory`), a default time difference of 5 seconds is assumed for speed calculation between the last two points. This is based on the typical interval of the source API data.
    - This change ensures that a prediction path can be generated and displayed in the 3D view immediately after page load, even before substantial live WebSocket data has been received.
    - If neither live nor historical data is sufficient, the predicted path (both text and 3D line) is cleared.

These changes improve the responsiveness of the prediction feature by providing an initial predicted path sooner and offer you more flexibility in setting the prediction length.