### PR TITLE
refactor: Update Three.js view to a responsive window layout

### DIFF
--- a/views/threejs_scene.ejs
+++ b/views/threejs_scene.ejs
@@ -4,15 +4,69 @@
     <%- include('partials/mainHead') %>
     <title>Three.js Scene</title>
     <style>
-        body { margin: 0; }
-        #threejs-container { width: 100%; height: calc(100vh - 112px); /* Adjusted for header and footer */ display: block; }
+        body { margin: 0; font-family: sans-serif; }
+        .main-centered-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 20px;
+            text-align: center;
+        }
+        .intro-text-section, .slider-form-section {
+            width: 80%;
+            max-width: 800px; /* Max width for text and form */
+            margin-bottom: 20px;
+        }
+        #threejs-container {
+            width: 80%; /* Responsive width */
+            max-width: 800px; /* Max width for the canvas */
+            height: 450px; /* Fixed height, or use aspect-ratio if preferred */
+            /* aspect-ratio: 16 / 9; */ /* Alternative to fixed height */
+            margin-bottom: 20px;
+            background-color: #f0f0f0; /* Light background for canvas area before it loads */
+            border: 1px solid #ccc; /* Optional border for the canvas */
+        }
+        /* Basic form styling */
+        .slider-form-section form div {
+            margin-bottom: 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .slider-form-section label {
+            margin-right: 10px;
+        }
+        .slider-form-section input[type="range"] {
+            flex-grow: 1;
+        }
     </style>
 </head>
 <body>
     <%- include('partials/nav') %>
-    <div id="threejs-container"></div>
-    <script src="/Projects/checkins/three.js"></script> <%# Path relative to public directory %>
-    <script src="/js/threejs_setup.js"></script> <%# Path relative to public directory %>
+
+    <div class="main-centered-container">
+        <div class="intro-text-section">
+            <p>Introductory text will go here.</p>
+        </div>
+
+        <div id="threejs-container"></div>
+
+        <div class="slider-form-section">
+            <form>
+                <div>
+                    <label for="slider1">Brightness:</label>
+                    <input type="range" id="slider1" name="slider1" min="0" max="100" value="70">
+                </div>
+                <div>
+                    <label for="slider2">Sphere Size:</label>
+                    <input type="range" id="slider2" name="slider2" min="10" max="100" value="50">
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script src="/Projects/checkins/three.js"></script>
+    <script src="/js/threejs_setup.js"></script>
     <%- include('partials/footer') %>
 </body>
 </html>


### PR DESCRIPTION
I modified `views/threejs_scene.ejs` to change the Three.js canvas from a fullscreen element to a responsive window within a new three-line centered page layout.

The new layout includes:
1. An introductory text section.
2. The Three.js canvas container, styled for responsiveness (80% width, max-width 800px, 450px height).
3. A placeholder form section for sliders.

CSS within the EJS file has been updated to support this centered, flex-column layout. The existing Three.js setup in `public/js/threejs_setup.js` was confirmed to correctly handle resizing based on its container, requiring no changes to the script itself.