### PR TITLE
fix: Update cloud texture to use Cloud_Map.jpg

### DIFF
--- a/public/js/threejs_setup.js
+++ b/public/js/threejs_setup.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
     scene.add(sphere);
 
     // Cloud Sphere
-    const cloudTexture = textureLoader.load('/img/cloudyEarth.jpg');
+    const cloudTexture = textureLoader.load('/img/Cloud_Map.jpg');
     cloudTexture.encoding = THREE.sRGBEncoding; // sRGBEncoding for color textures
 
     const cloudMaterial = new THREE.MeshPhongMaterial({ // Using MeshPhongMaterial for clouds for transparency options


### PR DESCRIPTION
I changed the texture reference in `public/js/threejs_setup.js` for the cloud layer from `cloudyEarth.jpg` to `Cloud_Map.jpg` as per your feedback.

This assumes `Cloud_Map.jpg` will be made available in the `public/img/` directory.