### PR TITLE
fix: Restrict Earth and cloud rotation to Y-axis

### DIFF
--- a/public/js/threejs_setup.js
+++ b/public/js/threejs_setup.js
@@ -132,12 +132,12 @@ document.addEventListener('DOMContentLoaded', () => {
         requestAnimationFrame(animate);
 
         // Optional: Add some animation to the sphere
-        sphere.rotation.x += 0.005;
-        sphere.rotation.y += 0.005;
+        // sphere.rotation.x += 0.005; // Remove or comment out X-axis rotation
+        sphere.rotation.y += 0.005; // Keep Y-axis rotation
 
         if (cloudSphere) { // Check if cloudSphere is defined
             cloudSphere.rotation.y += 0.0025; // Slower and slightly different rotation for clouds
-            cloudSphere.rotation.x += 0.001; // Slight axial tilt rotation for clouds
+            // cloudSphere.rotation.x += 0.001; // Remove or comment out X-axis rotation
         }
 
         renderer.render(scene, camera);


### PR DESCRIPTION
I modified the animation loop in `public/js/threejs_setup.js` to ensure that both the Earth sphere and the cloud sphere rotate exclusively around their Y-axis.

This provides a more standard planetary rotation effect, removing the previous X-axis tilt from the cloud layer and any X-axis rotation from the base sphere.