### PR TITLE
Fix ISS orbit predictor errors and improve robustness.

### DIFF
--- a/views/earth3D.ejs
+++ b/views/earth3D.ejs
@@ -141,13 +141,16 @@ window.ISSOrbitPredictor = (function () {
                        const i = lines.findIndex(l => l.includes('ISS (ZARYA)') || l.includes('ISS'));
                        if (i >= 0 && lines[i+1] && lines[i+2]) {
                            satrec = satellite.twoline2satrec(lines[i+1].trim(), lines[i+2].trim());
-                           // console.log("[ISSOrbitPredictor] Set satrec from cached TLE.");
-                       } else {
-                           console.error("[ISSOrbitPredictor] Could not parse TLE from cached text.");
-                           satrec = null;
-                           localStorage.removeItem(TLE_CACHE_KEY); // Remove invalid cached data
+                           if (satrec) { // Check if satrec was successfully initialized
+                               // console.log("[ISSOrbitPredictor] Set satrec from cached TLE.");
+                               return true;
+                           }
                        }
-                       return; // Return after using cache or failing to parse cache
+                       // If parsing failed or satrec is not valid from cache
+                       console.error("[ISSOrbitPredictor] Could not parse TLE from cached text or satrec invalid.");
+                       satrec = null;
+                       localStorage.removeItem(TLE_CACHE_KEY); // Remove invalid cached data
+                       return false;
                    } else {
                        console.log("[ISSOrbitPredictor] Cached TLE data expired.");
                    }
@@ -155,13 +158,19 @@ window.ISSOrbitPredictor = (function () {
            } catch (e) {
                console.error("[ISSOrbitPredictor] Error reading TLE from cache:", e);
                localStorage.removeItem(TLE_CACHE_KEY); // Clear corrupted cache
+               satrec = null;
+               return false;
            }
 
            // If cache is invalid, expired, or not present, fetch new TLE data from the network.
            try {
                console.log("[ISSOrbitPredictor] Fetching new TLE data from network.");
                const res = await fetch(TLE_URL);
-               if (!res.ok) throw new Error(`Failed to fetch TLE: ${res.status}`);
+               if (!res.ok) { // Check response status directly
+                   console.error(`[ISSOrbitPredictor] Failed to fetch TLE: ${res.status}`);
+                   satrec = null;
+                   return false;
+               }
                const txt = await res.text();
                
                // Store the newly fetched TLE data and current timestamp in localStorage.
@@ -178,14 +187,22 @@ window.ISSOrbitPredictor = (function () {
                const i = lines.findIndex(l => l.includes('ISS (ZARYA)') || l.includes('ISS'));
                if (i >= 0 && lines[i+1] && lines[i+2]) {
                    satrec = satellite.twoline2satrec(lines[i+1].trim(), lines[i+2].trim());
-               } else {
-                   console.error("[ISSOrbitPredictor] Could not parse TLE from fetched text.");
-                   satrec = null;
+                   if (satrec) { // Check if satrec was successfully initialized
+                       return true;
+                   }
                }
+               // If parsing failed or satrec is not valid from fetched TLE
+               console.error("[ISSOrbitPredictor] Could not parse TLE from fetched text or satrec invalid.");
+               satrec = null;
+               return false;
            } catch (error) {
                console.error("[ISSOrbitPredictor] Error fetching TLE:", error);
                satrec = null;
+               return false;
            }
+           // Fallback, though ideally all paths above should return.
+           satrec = null;
+           return false;
        }
 
        function positionAt(time) {
@@ -222,11 +239,11 @@ window.ISSOrbitPredictor = (function () {
     // Generates the full path and finds the first close pass
     async function calculateFullPredictionAndDeterminePass() {
         if (!satrec) {
-            const tleFetched = await fetchTLE();
-            if (!tleFetched) {
-                console.error("[ISSOrbitPredictor] TLE data unavailable. Cannot calculate full prediction.");
+            const tleSetupSuccess = await fetchTLE();
+            if (!tleSetupSuccess) {
+                console.error("[ISSOrbitPredictor] TLE data (satrec) could not be initialized. Cannot calculate full prediction.");
                 updatePassByText(null, Infinity); // Update text to show error/no pass
-                updatePredictionLengthSlider(DEFAULT_SLIDER_MAX_DURATION_SEC / 60); // Default slider range
+                updatePredictionLengthSlider(DEFAULT_SLIDER_MAX_DURATION_SEC / 60, DEFAULT_SLIDER_MAX_DURATION_SEC / 60); // Default slider range
                 displaySlicedPath(0); // Display no path
                 return;
             }
@@ -240,7 +257,7 @@ window.ISSOrbitPredictor = (function () {
 
         for (let t_sec = 0; t_sec < MAX_SEARCH_DURATION_SEC; t_sec += PREDICTION_INTERVAL_SEC) {
             const timeInstance = new Date(now.getTime() + t_sec * 1000);
-            const pos = positionAtTime(timeInstance);
+            const pos = positionAt(timeInstance);
             if (pos) {
                 fullCalculatedPath.push({ lat: pos.lat, lng: pos.lon, alt: pos.alt, time: t_sec });
                 const dist = haversineDistance(pos.lat, pos.lon, targetLat, targetLon);
@@ -282,10 +299,32 @@ window.ISSOrbitPredictor = (function () {
     function updatePredictionLengthSlider(maxMinutes, currentMinutes) {
         const slider = document.getElementById('predictionLengthSlider');
         const valueSpan = document.getElementById('predictionLengthValue');
-        if (slider && valueSpan) {
+
+        if (!slider) {
+            console.error("[ISSOrbitPredictor] predictionLengthSlider DOM element not found.");
+            return; // Gracefully exit if slider is missing
+        }
+        if (!valueSpan) {
+            console.error("[ISSOrbitPredictor] predictionLengthValue DOM element not found.");
+            // Depending on desired behavior, you might still want to update the slider if it exists,
+            // but for now, we'll also return if the valueSpan is missing.
+            return;
+        }
+
+        // Proceed with original logic only if both elements are found
+        if (typeof maxMinutes === 'number' && !isNaN(maxMinutes)) {
             slider.max = maxMinutes.toString();
+        } else {
+            console.warn("[ISSOrbitPredictor] Invalid maxMinutes for predictionLengthSlider:", maxMinutes);
+        }
+
+        if (typeof currentMinutes === 'number' && !isNaN(currentMinutes)) {
             slider.value = currentMinutes.toString();
             valueSpan.textContent = currentMinutes.toString();
+        } else {
+            console.warn("[ISSOrbitPredictor] Invalid currentMinutes for predictionLengthSlider:", currentMinutes);
+            // Optionally set a default text for valueSpan if currentMinutes is invalid
+            // valueSpan.textContent = 'N/A';
         }
     }
 


### PR DESCRIPTION
This commit addresses several issues in the ISS orbit predictor on the 3D earth view:

1.  Corrected a `ReferenceError` by changing `positionAtTime` to the correctly defined `positionAt` function.
2.  Resolved a `TypeError` in `updatePredictionLengthSlider` by ensuring both `maxMinutes` and `currentMinutes` arguments are provided when called during TLE fetch failures.
3.  Improved TLE fetching logic:
    *   `fetchTLE` now returns a boolean indicating success or failure in initializing the `satrec` object.
    *   `calculateFullPredictionAndDeterminePass` uses this boolean return value for more reliable error handling.
4.  Enhanced `updatePredictionLengthSlider` to:
    *   Verify that the required DOM elements (`predictionLengthSlider`, `predictionLengthValue`) exist before attempting to manipulate them.
    *   Validate that `maxMinutes` and `currentMinutes` parameters are valid numbers before use.

These changes make the ISS orbit prediction more resilient to errors, especially when TLE data is unavailable or DOM elements are missing.