### PR TITLE
feat: Add closest approach and end-of-path markers to 3D ISS view

### DIFF
--- a/public/js/earth3D.js
+++ b/public/js/earth3D.js
@@ -18,6 +18,16 @@ let cloudyEarth;
 let earthquakes;
 let issGif;
 
+// New marker variables
+let closestApproachMarker = {
+    visible: false,
+    lat: 0,
+    lon: 0,
+    alt: 0 // Store altitude if available/needed for positioning
+};
+// No specific global needed for end-of-path marker as it's derived from internalPredictedPath
+
+
 // Constants for sizes and distances
 const earthSize = 300;
 const earthActualRadiusKM = 6371; 
@@ -25,6 +35,14 @@ const issDistanceToEarth = 50;
 const gpsSize = 5; 
 const issSize = 6; 
 const CYLINDER_VISUAL_LENGTH = issDistanceToEarth * 3; // Now correctly uses defined constants
+
+// Constants for marker appearance
+const MARKER_COLOR_TEAL = [0, 128, 128]; // Teal
+const MARKER_COLOR_GREEN = [0, 200, 0]; // Green (matching predicted path)
+const USER_LOCATION_MARKER_SIZE = gpsSize;
+const CLOSEST_APPROACH_MARKER_SIZE = USER_LOCATION_MARKER_SIZE;
+const END_OF_PATH_MARKER_SIZE = USER_LOCATION_MARKER_SIZE / 2;
+
 
 // Global variables for the p5.js sketch (ensure these are below all const declarations they might depend on)
 // ... (rest of variable declarations like sketchPassByRadiusKM are effectively here or remain where they are if not dependent)
@@ -229,6 +247,37 @@ function draw() {
     pop();
 
     // --- DIAGNOSTIC LINE REMOVED ---
+
+    // Draw Closest Approach Marker (Teal)
+    if (window.ISSOrbitPredictor && typeof window.ISSOrbitPredictor.getClosestApproachDetails === 'function') {
+        const approachDetails = window.ISSOrbitPredictor.getClosestApproachDetails();
+        if (approachDetails) {
+            // Ensure approachDetails has lat, lon. alt might be optional or used if available.
+            // The ISS path is drawn at earthSize + issDistanceToEarth.
+            // The closest approach point should also be at this altitude relative to Earth's surface.
+            let vApproach = Tools.p5.getSphereCoord(earthSize + issDistanceToEarth, approachDetails.lat, approachDetails.lon);
+            push();
+            translate(vApproach.x, vApproach.y, vApproach.z);
+            noStroke();
+            fill(MARKER_COLOR_TEAL[0], MARKER_COLOR_TEAL[1], MARKER_COLOR_TEAL[2]); // Use defined Teal color
+            sphere(CLOSEST_APPROACH_MARKER_SIZE); // Use defined size
+            pop();
+        }
+    }
+
+    // Draw End of Prediction Path Marker (Green)
+    if (internalPredictedPath && internalPredictedPath.length > 0) {
+        const lastPoint = internalPredictedPath[internalPredictedPath.length - 1];
+        // Ensure lastPoint has lat, lon.
+        // Similar to the closest approach marker, position it relative to Earth's surface.
+        let vEndPath = Tools.p5.getSphereCoord(earthSize + issDistanceToEarth, lastPoint.lat, lastPoint.lon);
+        push();
+        translate(vEndPath.x, vEndPath.y, vEndPath.z);
+        noStroke();
+        fill(MARKER_COLOR_GREEN[0], MARKER_COLOR_GREEN[1], MARKER_COLOR_GREEN[2]); // Use defined Green color
+        sphere(END_OF_PATH_MARKER_SIZE); // Use defined size
+        pop();
+    }
 
     // Draw Pass-by Detection Cylinder (Standard Alignment)
     if (sketchPassByRadiusKM > 0) {

--- a/views/earth3D.ejs
+++ b/views/earth3D.ejs
@@ -84,6 +84,12 @@
                  <div style="margin-top: 5px;">
                     <span style="background-color: rgba(0,100,255,0.3); display: inline-block; width: 20px; height: 10px; margin-right: 5px; border: 1px solid #555;"></span> Pass-by Detection Radius
                 </div>
+                <div style="margin-top: 5px;">
+                    <span style="background-color: teal; display: inline-block; width: 10px; height: 10px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> Point of Closest Approach (if detected)
+                </div>
+                <div style="margin-top: 5px;">
+                    <span style="background-color: green; display: inline-block; width: 7px; height: 7px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> End of Predicted Path
+                </div>
             </div>
 
             <div style="padding: 10px; text-align: left; border-top: 1px solid #eee;">
@@ -124,6 +130,7 @@ window.ISSOrbitPredictor = (function () {
 
     let fullCalculatedPath = []; // Stores all points up to MAX_SEARCH_DURATION_SEC
     let timeToFirstClosePassSec = null; // Time in seconds to the first detected pass
+    let exposedClosestApproachDetails = null; // Stores details of the closest approach
 
        // Fetches TLE data for ISS, using localStorage caching to reduce network requests
        // and avoid potential 403 errors from excessive downloads from Celestrak.
@@ -242,6 +249,7 @@ window.ISSOrbitPredictor = (function () {
             const tleSetupSuccess = await fetchTLE();
             if (!tleSetupSuccess) {
                 console.error("[ISSOrbitPredictor] TLE data (satrec) could not be initialized. Cannot calculate full prediction.");
+                exposedClosestApproachDetails = null; // Ensure details are cleared on TLE error
                 updatePassByText(null, Infinity); // Update text to show error/no pass
                 updatePredictionLengthSlider(DEFAULT_SLIDER_MAX_DURATION_SEC / 60, DEFAULT_SLIDER_MAX_DURATION_SEC / 60); // Default slider range
                 displaySlicedPath(0); // Display no path
@@ -273,6 +281,20 @@ window.ISSOrbitPredictor = (function () {
         }
         console.log(`[ISSOrbitPredictor] Full path calculated. Points: ${fullCalculatedPath.length}. Closest overall: ${closestOverallDistance.toFixed(0)}km at ${closestOverallPoint ? closestOverallPoint.time/60 : 'N/A'} mins.`);
         
+        if (closestOverallPoint && closestOverallDistance < currentRadiusKM) {
+            exposedClosestApproachDetails = {
+                lat: closestOverallPoint.lat,
+                lon: closestOverallPoint.lon,
+                alt: closestOverallPoint.alt, // Assumes alt is part of closestOverallPoint from '...pos'
+                time: closestOverallPoint.time,
+                dist: closestOverallDistance
+            };
+            // console.log('[ISSOrbitPredictor] Closest approach details updated:', exposedClosestApproachDetails);
+        } else {
+            exposedClosestApproachDetails = null;
+            // console.log('[ISSOrbitPredictor] No close approach within radius, details cleared.');
+        }
+
         updatePassByText(closestOverallPoint, closestOverallDistance);
         
         let sliderMaxDurationSec = timeToFirstClosePassSec !== null ? timeToFirstClosePassSec : DEFAULT_SLIDER_MAX_DURATION_SEC;
@@ -349,6 +371,9 @@ window.ISSOrbitPredictor = (function () {
             // Recalculate to find new timeToFirstClosePassSec and update slider/text
             // This will re-use existing TLE if already fetched and satrec is valid.
             calculateFullPredictionAndDeterminePass(); 
+        },
+        getClosestApproachDetails: function() {
+            return exposedClosestApproachDetails;
         }
     };
 })();


### PR DESCRIPTION
This commit introduces two new visual markers to the 3D ISS trajectory display:

1.  **Closest Approach Marker:**
    *   A teal-colored sphere, similar in size to your location marker.
    *   Appears at the calculated point of closest approach if the ISS is predicted to pass within your defined detection radius.
    *   The `ISSOrbitPredictor` was updated to store and expose these details.

2.  **End of Prediction Path Marker:**
    *   A smaller, green-colored sphere (matching the prediction path color).
    *   Always displayed at the very end of the currently rendered predicted path segment.

Global variables and constants for marker appearance (colors, sizes) were added to `earth3D.js`. The `draw()` function in `earth3D.js` was updated to render these markers, ensuring they are part of the main rotational context.

The HTML legend in `views/earth3D.ejs` has also been updated to include descriptions for these new markers.