### PR TITLE
Fix: Further attempt to resolve Moment.js warning and chart overlap

### DIFF
--- a/public/Projects/Tides/index.html
+++ b/public/Projects/Tides/index.html
@@ -17,7 +17,7 @@
 
   <h1>Current Tide Level in Quebec</h1>
   <p id="currentTide"></p>
-  <div style="position: relative; width: 1024px; height: 320px; margin-bottom: 20px;">
+  <div style="position: relative; width: 1024px; height: 400px; margin-bottom: 20px;">
     <div style="
         position: absolute;
         top: 32px;  
@@ -121,8 +121,13 @@
                             },
                             ticks: {
                                 callback: function(value, index, values) {
-                                    // 'value' for a time scale is typically the millisecond timestamp
-                                    // Moment.js can directly handle this numeric value.
+                                    // console.log('Chart tick callback value:', value, 'values[index]:', values[index]);
+                                    // For Chart.js time scales, values[index].value often holds the timestamp.
+                                    if (values && values[index] && typeof values[index].value === 'number') {
+                                        return moment(values[index].value).format('ddd D MMM HH:mm');
+                                    }
+                                    // Fallback if the structure is different, though this might still cause warnings if 'value' is a problematic string.
+                                    // The console.log above should help identify the correct structure if this fallback is hit.
                                     return moment(value).format('ddd D MMM HH:mm');
                                 }
                             }


### PR DESCRIPTION
- Updated Chart.js xAxes ticks.callback to preferentially use `values[index].value` for timestamps, aiming to fix Moment.js deprecation warnings. Includes a commented console.log for easier debugging if the issue remains.
- Adjusted the height of the chart's parent container to match the canvas height (400px) and ensured a margin-bottom, to prevent UI overlap with the control form.