### PR TITLE
fix: Invert vertical drag rotation for Earth3D

### DIFF
--- a/public/js/earth3D.js
+++ b/public/js/earth3D.js
@@ -384,8 +384,8 @@ function mouseDragged() {
     if (mouseX > 0 && mouseX < width && mouseY > 0 && mouseY < height) {
         let dx = mouseX - pmouseX;
         let dy = mouseY - pmouseY;
-        angleY += dx * 0.01; // dx controls angleY (yaw)
-        angleX += dy * 0.01; // dy controls angleX (pitch)
+        angleY += dx * 0.01; // dx controls angleY (yaw) - direction remains as is
+        angleX -= dy * 0.01; // dy controls angleX (pitch) - INVERTED direction
         angleX = constrain(angleX, -Math.PI/2.1, Math.PI/2.1); // Keep constraint on pitch
         return false; // Prevent default browser drag behaviors ONLY when rotating globe
     }


### PR DESCRIPTION
Modified the mouseDragged function in earth3D.js to invert the pitch rotation (angleX) controlled by vertical mouse drag. The update `angleX += dy * 0.01` is now `angleX -= dy * 0.01`.

This change ensures that dragging the mouse downwards tilts the top of the Earth towards the user (camera pitches up), and dragging upwards tilts the top away (camera pitches down), providing a more natural control feel.

Horizontal drag (yaw) behavior remains unchanged. The rotation order in draw() also remains `rotateX` then `rotateY`.