### PR TITLE
Add earthquake appearance customization to Earth3D view

### DIFF
--- a/public/js/earth3D.js
+++ b/public/js/earth3D.js
@@ -18,6 +18,11 @@ let cloudyEarth;
 let earthquakes;
 let issGif;
 
+// Quake visualization parameters
+let quakeFromColor;
+let quakeToColor;
+let quakeMagFactor = 1.0; // Default magnitude factor
+
 // New marker variables
 let closestApproachMarker = {
     visible: false,
@@ -59,6 +64,10 @@ function setup() {
     var canvas = createCanvas(1280, 720, WEBGL);
     canvas.parent('sketch-holder');
     controlsOverlayElement = document.getElementById('controls-overlay');
+
+    // Initialize quake colors
+    quakeFromColor = color(0, 255, 0, 150); // Default fromColor (green)
+    quakeToColor = color(255, 0, 0, 150); // Default toColor (red)
 }
 
 function keyPressed() {
@@ -357,9 +366,10 @@ function show3DQuakes() {
         if (isNaN(lat) || isNaN(lon) || isNaN(mag)) continue;
         let pos = Tools.p5.getSphereCoord(earthSize, lat, lon);
         var h = pow(10, mag); var maxh = pow(10, 8);
-        h = map(h, 0, maxh, 1, Math.min(mag * 5, 100));
-        let fromColor = color(0, 255, 0, 150); let toColor = color(255, 0, 0, 150);
-        let quakeColor = lerpColor(fromColor, toColor, map(mag, 0, 8, 0, 1));
+        // Apply quakeMagFactor to the size calculation
+        h = map(h, 0, maxh, 1, Math.min(mag * 5 * quakeMagFactor, 100 * quakeMagFactor));
+        // Use global quakeFromColor and quakeToColor
+        let quakeColor = lerpColor(quakeFromColor, quakeToColor, map(mag, 0, 8, 0, 1));
         push(); translate(pos.x, pos.y, pos.z); fill(quakeColor); noStroke(); sphere(Math.max(1, h / 10)); pop();
     }
 }

--- a/views/earth3D.ejs
+++ b/views/earth3D.ejs
@@ -101,6 +101,25 @@
                 <div style="margin-top: 5px;">
                     <span style="background-color: green; display: inline-block; width: 7px; height: 7px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> End of Predicted Path
                 </div>
+                <div style="margin-top: 5px;">
+                    <span style="background-color: #00FF00; display: inline-block; width: 10px; height: 10px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> Earthquake (Low Magnitude - Color transitions based on magnitude, size affected by Mag. Factor)
+                </div>
+            </div>
+
+            <div style="padding: 10px; text-align: left; border-top: 1px solid #eee;">
+                <strong>Quake Appearance:</strong>
+                <div style="margin-top: 5px;">
+                    <label for="quakeFromColor">From Color:</label>
+                    <input type="color" id="quakeFromColor" value="#00FF00"> <!-- Default Green -->
+                </div>
+                <div style="margin-top: 5px;">
+                    <label for="quakeToColor">To Color:</label>
+                    <input type="color" id="quakeToColor" value="#FF0000"> <!-- Default Red -->
+                </div>
+                <div style="margin-top: 5px;">
+                    <label for="quakeMagFactor">Magnitude Factor: <span id="quakeMagFactorValue">1.0</span></label>
+                    <input type="range" id="quakeMagFactor" min="0.1" max="5" step="0.1" value="1.0" style="width: 100%;">
+                </div>
             </div>
 
             <div style="padding: 10px; text-align: left; border-top: 1px solid #eee;">
@@ -550,6 +569,61 @@ window.ISSOrbitPredictor = (function () {
 
         if (window.ISSOrbitPredictor) {
             window.ISSOrbitPredictor.fetchAndPredict();
+        }
+
+        // Quake appearance controls
+        const quakeFromColorInput = document.getElementById('quakeFromColor');
+        const quakeToColorInput = document.getElementById('quakeToColor');
+        const quakeMagFactorInput = document.getElementById('quakeMagFactor');
+        const quakeMagFactorValueSpan = document.getElementById('quakeMagFactorValue');
+
+        if (quakeFromColorInput) {
+            quakeFromColorInput.addEventListener('input', function() {
+                if (window.earth3DSketch && typeof quakeFromColor !== 'undefined') {
+                    // p5.js color function is available in the global scope of the sketch
+                    // but earth3D.js's setup() initializes quakeFromColor.
+                    // We need to update that specific variable.
+                    // Direct assignment might be tricky if earth3D.js is not fully loaded or
+                    // if p5 instance is not directly accessible here in the same way.
+                    // A robust way is to expose a setter in earth3DSketch object.
+                    // For now, assuming direct update works or will be refined.
+                    // Let's create new p5.Color objects from the hex value.
+                    // This assumes p5 is loaded and `color()` is available globally.
+                    try {
+                        let newColor = color(this.value); // p5.color()
+                        newColor.setAlpha(150); // Keep original alpha
+                        quakeFromColor = newColor; // Update global in earth3D.js
+                         if (typeof redraw === 'function') redraw(); // Redraw sketch
+                    } catch (e) {
+                        console.error("Error creating color for quakeFromColor:", e);
+                    }
+                }
+            });
+        }
+
+        if (quakeToColorInput) {
+            quakeToColorInput.addEventListener('input', function() {
+                if (window.earth3DSketch && typeof quakeToColor !== 'undefined') {
+                     try {
+                        let newColor = color(this.value); // p5.color()
+                        newColor.setAlpha(150); // Keep original alpha
+                        quakeToColor = newColor; // Update global in earth3D.js
+                        if (typeof redraw === 'function') redraw(); // Redraw sketch
+                    } catch (e) {
+                        console.error("Error creating color for quakeToColor:", e);
+                    }
+                }
+            });
+        }
+
+        if (quakeMagFactorInput && quakeMagFactorValueSpan) {
+            quakeMagFactorInput.addEventListener('input', function() {
+                quakeMagFactorValueSpan.textContent = this.value;
+                if (window.earth3DSketch && typeof quakeMagFactor !== 'undefined') {
+                    quakeMagFactor = parseFloat(this.value); // Update global in earth3D.js
+                    if (typeof redraw === 'function') redraw(); // Redraw sketch
+                }
+            });
         }
     });
 </script>


### PR DESCRIPTION
- Added global variables for quakeFromColor, quakeToColor, and quakeMagFactor in earth3D.js.
- Updated show3DQuakes() to use these global variables.
- Added a form in earth3D.ejs with color pickers and a range slider to control these parameters.
- Implemented JavaScript to update the global variables and redraw the sketch on form input changes.
- Updated the legend to reflect the new customizable earthquake representation.