### PR TITLE
Refine quake legend and add visibility toggles

### DIFF
--- a/public/js/earth3D.js
+++ b/public/js/earth3D.js
@@ -23,6 +23,11 @@ let quakeFromColor;
 let quakeToColor;
 let quakeMagFactor = 1.0; // Default magnitude factor
 
+// Visibility toggles
+let showIssHistoricalPath = true;
+let showIssPredictedPath = true;
+let showQuakes = true;
+
 // New marker variables
 let closestApproachMarker = {
     visible: false,
@@ -215,7 +220,7 @@ function draw() {
         pop();
     }
 
-    if (internalIssPathHistory && internalIssPathHistory.length > 0) {
+    if (showIssHistoricalPath && internalIssPathHistory && internalIssPathHistory.length > 0) {
         push();
         noStroke();
         fill(255, 165, 0, 150);
@@ -229,7 +234,7 @@ function draw() {
         pop();
     }
 
-    if (internalPredictedPath && internalPredictedPath.length > 1) {
+    if (showIssPredictedPath && internalPredictedPath && internalPredictedPath.length > 1) {
         push();
         stroke(0, 200, 0, 180);
         strokeWeight(1.5);
@@ -332,7 +337,9 @@ function draw() {
         pop();
     }
 
-    show3DQuakes();
+    if (showQuakes) {
+        show3DQuakes();
+    }
 
     // Note: The pop(); that was here, which matched the second rotateY group, is removed.
     // All elements are now part of the single main rotation group.

--- a/views/earth3D.ejs
+++ b/views/earth3D.ejs
@@ -68,6 +68,21 @@
                         <label for="passByRadiusSlider" style="font-size: 0.85em; display: block; margin-bottom: 2px;">Detect Radius: <span id="passByRadiusValue">1500</span> km</label>
                         <input type="range" id="passByRadiusSlider" min="250" max="3000" step="50" value="1500" style="width: 100%; margin-top: -2px;">
                     </div>
+                    <hr style="border-top: 1px solid rgba(255,255,255,0.2); margin-top: 8px; margin-bottom: 8px;">
+                    <div style="font-size: 0.85em;">
+                        <div style="margin-bottom: 4px;">
+                            <input type="checkbox" id="showIssHistoricalPath" checked>
+                            <label for="showIssHistoricalPath" style="margin-left: 4px;">Show Hist. Path</label>
+                        </div>
+                        <div style="margin-bottom: 4px;">
+                            <input type="checkbox" id="showIssPredictedPath" checked>
+                            <label for="showIssPredictedPath" style="margin-left: 4px;">Show Pred. Path</label>
+                        </div>
+                        <div>
+                            <input type="checkbox" id="showQuakes" checked>
+                            <label for="showQuakes" style="margin-left: 4px;">Show Quakes</label>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -101,9 +116,6 @@
                 <div style="margin-top: 5px;">
                     <span style="background-color: green; display: inline-block; width: 7px; height: 7px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> End of Predicted Path
                 </div>
-                <div style="margin-top: 5px;">
-                    <span style="background-color: #00FF00; display: inline-block; width: 10px; height: 10px; margin-right: 5px; border: 1px solid #555; border-radius: 50%;"></span> Earthquake (Low Magnitude - Color transitions based on magnitude, size affected by Mag. Factor)
-                </div>
             </div>
 
             <div style="padding: 10px; text-align: left; border-top: 1px solid #eee;">
@@ -120,6 +132,9 @@
                     <label for="quakeMagFactor">Magnitude Factor: <span id="quakeMagFactorValue">1.0</span></label>
                     <input type="range" id="quakeMagFactor" min="0.1" max="5" step="0.1" value="1.0" style="width: 100%;">
                 </div>
+                <small style="display: block; margin-top: 8px;">
+                    Note: Quake color transitions from 'From Color' to 'To Color' based on magnitude. 'Magnitude Factor' affects the size of the quake spheres.
+                </small>
             </div>
 
             <div style="padding: 10px; text-align: left; border-top: 1px solid #eee;">
@@ -622,6 +637,38 @@ window.ISSOrbitPredictor = (function () {
                 if (window.earth3DSketch && typeof quakeMagFactor !== 'undefined') {
                     quakeMagFactor = parseFloat(this.value); // Update global in earth3D.js
                     if (typeof redraw === 'function') redraw(); // Redraw sketch
+                }
+            });
+        }
+
+        // Visibility checkbox handlers
+        const showIssHistoricalPathCheckbox = document.getElementById('showIssHistoricalPath');
+        const showIssPredictedPathCheckbox = document.getElementById('showIssPredictedPath');
+        const showQuakesCheckbox = document.getElementById('showQuakes');
+
+        if (showIssHistoricalPathCheckbox) {
+            showIssHistoricalPathCheckbox.addEventListener('change', function() {
+                if (typeof showIssHistoricalPath !== 'undefined') {
+                    showIssHistoricalPath = this.checked;
+                    if (typeof redraw === 'function') redraw();
+                }
+            });
+        }
+
+        if (showIssPredictedPathCheckbox) {
+            showIssPredictedPathCheckbox.addEventListener('change', function() {
+                if (typeof showIssPredictedPath !== 'undefined') {
+                    showIssPredictedPath = this.checked;
+                    if (typeof redraw === 'function') redraw();
+                }
+            });
+        }
+
+        if (showQuakesCheckbox) {
+            showQuakesCheckbox.addEventListener('change', function() {
+                if (typeof showQuakes !== 'undefined') {
+                    showQuakes = this.checked;
+                    if (typeof redraw === 'function') redraw();
                 }
             });
         }


### PR DESCRIPTION
- Moved earthquake color/magnitude information from the main legend to a note within the 'Quake Appearance' form.
- Added checkboxes to the controls overlay to toggle the visibility of:
  - ISS Historical Path
  - ISS Predicted Path
  - Quake Spheres
- Updated earth3D.js to handle these visibility states and conditionally render the elements.
- Added JavaScript in earth3D.ejs to link checkbox changes to the visibility variables and trigger redraws.