### PR TITLE
Fix: Checkbox visibility toggles for ISS paths and quakes

### DIFF
--- a/public/js/earth3D.js
+++ b/public/js/earth3D.js
@@ -386,7 +386,19 @@ window.earth3DSketch = {
     updatePredictedPath: update3DPredictedPath,
     getInternalIssPathHistory: () => internalIssPathHistory,
     getMaxHistoryPoints: () => MAX_HISTORY_POINTS,
-    setSketchPassByRadiusKM: setSketchPassByRadiusKM
+    setSketchPassByRadiusKM: setSketchPassByRadiusKM,
+    setShowIssHistoricalPath: function(value) {
+        showIssHistoricalPath = !!value; // Ensure boolean
+        if (typeof redraw === 'function') redraw();
+    },
+    setShowIssPredictedPath: function(value) {
+        showIssPredictedPath = !!value; // Ensure boolean
+        if (typeof redraw === 'function') redraw();
+    },
+    setShowQuakes: function(value) {
+        showQuakes = !!value; // Ensure boolean
+        if (typeof redraw === 'function') redraw();
+    }
 };
 
 function mouseDragged() {

--- a/views/earth3D.ejs
+++ b/views/earth3D.ejs
@@ -648,27 +648,24 @@ window.ISSOrbitPredictor = (function () {
 
         if (showIssHistoricalPathCheckbox) {
             showIssHistoricalPathCheckbox.addEventListener('change', function() {
-                if (typeof showIssHistoricalPath !== 'undefined') {
-                    showIssHistoricalPath = this.checked;
-                    if (typeof redraw === 'function') redraw();
+                if (window.earth3DSketch && typeof window.earth3DSketch.setShowIssHistoricalPath === 'function') {
+                    window.earth3DSketch.setShowIssHistoricalPath(this.checked);
                 }
             });
         }
 
         if (showIssPredictedPathCheckbox) {
             showIssPredictedPathCheckbox.addEventListener('change', function() {
-                if (typeof showIssPredictedPath !== 'undefined') {
-                    showIssPredictedPath = this.checked;
-                    if (typeof redraw === 'function') redraw();
+                if (window.earth3DSketch && typeof window.earth3DSketch.setShowIssPredictedPath === 'function') {
+                    window.earth3DSketch.setShowIssPredictedPath(this.checked);
                 }
             });
         }
 
         if (showQuakesCheckbox) {
             showQuakesCheckbox.addEventListener('change', function() {
-                if (typeof showQuakes !== 'undefined') {
-                    showQuakes = this.checked;
-                    if (typeof redraw === 'function') redraw();
+                if (window.earth3DSketch && typeof window.earth3DSketch.setShowQuakes === 'function') {
+                    window.earth3DSketch.setShowQuakes(this.checked);
                 }
             });
         }


### PR DESCRIPTION
- Exposed setter functions (setShowIssHistoricalPath, setShowIssPredictedPath, setShowQuakes) via window.earth3DSketch in earth3D.js to reliably update visibility states from external event handlers.
- Modified checkbox event handlers in earth3D.ejs to use these setter functions.
- Ensured redraw is called within the setter functions in earth3D.js after updating visibility state. This corrects the issue where checkboxes had no effect due to scope/initialization timing of visibility variables.